### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/multiplicity3-parent/multiplicity3-appsystem/pom.xml
+++ b/multiplicity3-parent/multiplicity3-appsystem/pom.xml
@@ -36,7 +36,7 @@
 <dependency>
 	<groupId>commons-collections</groupId>
 	<artifactId>commons-collections</artifactId>
-	<version>3.2.1</version>
+	<version>3.2.2</version>
 	<type>jar</type>
 	<scope>compile</scope>
 </dependency>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
